### PR TITLE
Add ESAPI extension to final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,9 @@ RUN box install commandbox-cfconfig
 
 RUN box install commandbox-docbox
 
+# ESAPI extension for testbox run
+ADD https://ext.lucee.org/esapi-extension-2.2.0.1.lex /root/.CommandBox/engine/cfml/cli/lucee-server/deploy/esapi-extension-2.2.0.1.lex
+
 #output some version info so we have it in the build logs
 
 RUN echo "VERSION INFORMATION"

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ RUN box install commandbox-cfconfig
 
 RUN box install commandbox-docbox
 
-# ESAPI extension for testbox run
-ENV LUCEE_EXTENSIONS="$LUCEE_EXTENSIONS,37C61C0A-5D7E-4256-8572639BE0CF5838"
-
 #output some version info so we have it in the build logs
 
 RUN echo "VERSION INFORMATION"
@@ -37,6 +34,9 @@ RUN box cfformat run /tmp/test.cfc
 
 
 FROM foundeo/minibox:latest
+
+# ESAPI extension for testbox run
+ENV LUCEE_EXTENSIONS="$LUCEE_EXTENSIONS,37C61C0A-5D7E-4256-8572639BE0CF5838"
 
 COPY --from=build /root/.CommandBox/cfml/modules /root/.CommandBox/cfml/modules 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN box install commandbox-cfconfig
 RUN box install commandbox-docbox
 
 # ESAPI extension for testbox run
-ADD https://ext.lucee.org/esapi-extension-2.2.0.1.lex /root/.CommandBox/engine/cfml/cli/lucee-server/deploy/esapi-extension-2.2.0.1.lex
+ENV LUCEE_EXTENSIONS="$LUCEE_EXTENSIONS,37C61C0A-5D7E-4256-8572639BE0CF5838"
 
 #output some version info so we have it in the build logs
 


### PR DESCRIPTION
Adds the ESAPI lucee extension into the lucee server for use by certain commands like `box testbox run`. The testbox runner uses ESAPI functions (for obvious reasons :wink:  and needs this extension installed to work properly.)

Note that currently, the `LUCEE_EXTENSIONS` env var needs to be configured in the _final_ build docker image. The way the Dockerfile is structured into two separate images causes the installed extension to be "left behind" when the second docker image is built. It may be possible instead to use a `COPY -form=build` line to copy the extension `.lex` file to the new image just like the commandbox modules. So far, I couldn't get that working, but the change in this PR does indeed work and run ESAPI methods like `encodeForURL()`.

```bash
docker build -t cfml-ci-tools .
docker run --name CFMLCItest cfml-ci box -cliworkingdir=/opt '#encodeForURL' fo%o
```