### PR TITLE
Add test for "testbox run" command

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,4 +10,5 @@ sut:
     && cd /tmp/cfml-ci-examples/
     && git clone https://github.com/foundeo/cfml-ci-examples.git .
     && box cflint reportLevel=ERROR
-    && box codechecker run"
+    && box codechecker run
+    && testbox run runner=http://localhost/index.cfm"


### PR DESCRIPTION
I'm seeing errors when running `testbox run` in minibox. That issue aside, would a `testbox run` test be useful when building this image?